### PR TITLE
Files Sync From fuelviews/github-workflow-sync

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -35,11 +35,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.bump_version.outputs.new_tag }}
-          release_name: Release ${{ steps.bump_version.outputs.new_tag }}
-          body: |
-            Changes in this Release:
-
-            ${{ github.event.pull_request.title }}
-            ${{ github.event.pull_request.body }}
+          release_name: ${{ steps.bump_version.outputs.new_tag }}
           draft: true
           prerelease: false


### PR DESCRIPTION
Focuses on syncing files from the fuelviews/github-workflow-sync repository to our project. The change in the auto-release workflow removes the automatic inclusion of pull request title and body in the release notes. Instead, it now sets the release name to the new tag name generated during the version bump.

By updating the release configuration in the auto-release workflow, we ensure that the release notes are cleaner and more focused on the version changes. This streamlining will make it easier for users and contributors to understand the contents of each release without unnecessary clutter.

In summary, this change improves the clarity and organization of our release notes, making it simpler for stakeholders to track changes in each release.