### PR TITLE
Add default GitHub action workflow for cPanel auto deploy and specify triggers for PRs to the development and main branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,15 @@ composer require fuelviews/laravel-cpanel-auto-deploy
 
 You can copy the default github action workflow from resources/workfllows/cpanel-auto-deploy.yml into .github/workflows/cpanel-auto-deploy.yml
 
-**Default github action workflow trigger's on PR to development branch
+**Default github action workflow triggers on PR to development branch
 
 ## Usage
 
-You can manually run the script in a terminal with:
+You can manually run the script in terminal with:
 
 ```bash
 ./cpanel-auto-deploy.sh
 ```
-
-You will likely
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ You can require the package and it's dependencies via composer:
 composer require fuelviews/laravel-cpanel-auto-deploy
 ```
 
+You can copy the default github action workflow from resources/workfllows/cpanel-auto-deploy.yml into .github/workflows/cpanel-auto-deploy.yml
+
+**Default github action workflow trigger's on PR to development branch
+
 ## Usage
 
 You can manually run the script in a terminal with:

--- a/resources/workflows/cpanel-auto-deploy.yml.stub
+++ b/resources/workflows/cpanel-auto-deploy.yml.stub
@@ -1,0 +1,38 @@
+name: "cPanel Auto Deploy"
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - development
+    paths-ignore:
+      - 'CHANGELOG.md'
+
+jobs:
+  deploy-development:
+    if: github.ref == 'refs/heads/development' || (github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'development')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Deploy to Development Server
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.DEVELOPMENT_HOST }}
+          username: ${{ secrets.DEVELOPMENT_USERNAME }}
+          port: ${{ secrets.DEVELOPMENT_PORT }}
+          key: ${{ secrets.DEVELOPMENT_SSH_KEY }}
+          script: "cd $HOME/app && /bin/chmod +x ./cpanel-auto-deploy.sh && ./cpanel-auto-deploy.sh"
+
+  deploy-production:
+    if: github.ref == 'refs/heads/main' || (github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Deploy to Production Server
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.PRODUCTION_HOST }}
+          username: ${{ secrets.PRODUCTION_USERNAME }}
+          port: ${{ secrets.PRODUCTION_PORT }}
+          key: ${{ secrets.PRODUCTION_SSH_KEY }}
+          script: "cd $HOME/app && /bin/chmod +x ./cpanel-auto-deploy.sh && ./cpanel-auto-deploy.sh"


### PR DESCRIPTION
Introduces a default GitHub action workflow for cPanel auto-deployment and specifies triggers for pull requests targeting the development and main branches. The workflow is designed to automatically deploy changes to the respective servers upon PR merges or branch updates.

By adding this automated deployment process, we streamline the deployment workflow and ensure that changes are promptly deployed to the appropriate environments without manual intervention. This enhancement improves efficiency and reduces the risk of deployment errors, ultimately enhancing the project's deployment reliability and consistency.