### PR TITLE
Fix command

### DIFF
--- a/src/Commands/InstallWorkflowCommand.php
+++ b/src/Commands/InstallWorkflowCommand.php
@@ -4,14 +4,11 @@ namespace Fuelviews\CpanelAutoDeploy\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
-use Symfony\Component\Process\Exception\ProcessFailedException;
-use Symfony\Component\Process\Process;
-
-use function Laravel\Prompts\confirm;
 
 class InstallWorkflowCommand extends Command
 {
     protected $signature = 'deploy:install';
+
     protected $description = 'Install all Fuelviews packages and run their install commands';
 
     public function __construct()
@@ -25,7 +22,7 @@ class InstallWorkflowCommand extends Command
         $destination = base_path('.github/workflows/cpanel-auto-deploy.yml');
 
         $directory = dirname($destination);
-        if (!File::exists($directory)) {
+        if (! File::exists($directory)) {
             File::makeDirectory($directory);
         }
 

--- a/src/Commands/InstallWorkflowCommand.php
+++ b/src/Commands/InstallWorkflowCommand.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\File;
 
 class InstallWorkflowCommand extends Command
 {
-    protected $signature = 'deploy:install';
+    protected $signature = 'laravel-cpanel-auto-deploy:install';
 
     protected $description = 'Install all Fuelviews packages and run their install commands';
 

--- a/src/Commands/InstallWorkflowCommand.php
+++ b/src/Commands/InstallWorkflowCommand.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Fuelviews\CpanelAutoDeploy\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
+
+use function Laravel\Prompts\confirm;
+
+class InstallWorkflowCommand extends Command
+{
+    protected $signature = 'deploy:install';
+    protected $description = 'Install all Fuelviews packages and run their install commands';
+
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function handle()
+    {
+        $source = resource_path('workflows/cpanel-auto-deploy.yml.stub');
+        $destination = base_path('.github/workflows/cpanel-auto-deploy.yml');
+
+        $directory = dirname($destination);
+        if (!File::exists($directory)) {
+            File::makeDirectory($directory);
+        }
+
+        if (File::copy($source, $destination)) {
+            $this->info('Workflow file copied successfully.');
+        } else {
+            $this->error('Failed to copy workflow file.');
+        }
+    }
+}

--- a/src/Commands/InstallWorkflowCommand.php
+++ b/src/Commands/InstallWorkflowCommand.php
@@ -9,7 +9,6 @@ class InstallWorkflowCommand extends Command
 {
     protected $signature = 'deploy:install';
 
-
     protected $description = 'Install all Fuelviews packages and run their install commands';
 
     public function __construct()

--- a/src/CpanelAutoDeploy.php
+++ b/src/CpanelAutoDeploy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Fuelviews\CpanelAutoDeploy;
+
+class CpanelAutoDeploy
+{
+}

--- a/src/CpanelAutoDeployServiceProvider.php
+++ b/src/CpanelAutoDeployServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Fuelviews\CpanelAutoDeploy;
 
+use Fuelviews\CpanelAutoDeploy\Commands\InstallWorkflowCommand;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -10,6 +11,7 @@ class CpanelAutoDeployServiceProvider extends PackageServiceProvider
     public function configurePackage(Package $package): void
     {
         $package
+            ->hasCommand(InstallWorkflowCommand::class)
             ->name('laravel-cpanel-auto-deploy');
     }
 

--- a/src/Facades/CpanelAutoDeploy.php
+++ b/src/Facades/CpanelAutoDeploy.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Fuelviews\CpanelAutoDeploy\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @see \Fuelviews\CpanelAutoDeploy\CpanelAutoDeploy
+ */
+class CpanelAutoDeploy extends Facade
+{
+    protected static function getFacadeAccessor()
+    {
+        return \Fuelviews\CpanelAutoDeploy\CpanelAutoDeploy::class;
+    }
+}


### PR DESCRIPTION
Addresses the issue with the command structure in the project by adding the missing `InstallWorkflowCommand` command to the `CpanelAutoDeployServiceProvider`. Additionally, it introduces the `CpanelAutoDeploy` facade to allow for easier access to the `CpanelAutoDeploy` class.

By incorporating the `InstallWorkflowCommand` and setting up the facade, this fix enhances the usability and functionality of the project. The command now correctly integrates with the service provider, ensuring a smoother workflow for users interacting with the package.

These changes will help streamline the command execution process and improve the overall organization of the project's structure.